### PR TITLE
Stop Camera snapping in Main Menu & other small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 StationeersVRMod/.vs/
 /.vs
+/.vscode

--- a/StationeersVRMod/Patches/MainMenuPatches.cs
+++ b/StationeersVRMod/Patches/MainMenuPatches.cs
@@ -2,7 +2,6 @@
 using HarmonyLib;
 using StationeersVR.Utilities;
 using UnityEngine;
-using Valve.VR;
 using Assets.Scripts.UI;
 using JetBrains.Annotations;
 using UnityEngine.UI;
@@ -11,6 +10,38 @@ using UnityEngine.EventSystems;
 
 namespace StationeersVR
 {
+
+    public class TransformLock : MonoBehaviour
+    {
+        Quaternion fixedRotation = Quaternion.identity;
+        Vector3 fixedPosition = new Vector3();
+        bool isLocked = true;
+
+        void Update()
+        {
+            if (isLocked)
+            {
+                transform.rotation = fixedRotation;
+                transform.position = fixedPosition;
+            }
+        }
+
+        public void SetRotation(Quaternion quaternion)
+        {
+            fixedRotation = quaternion;
+        }
+
+        public void SetPosition(Vector3 position)
+        {
+            fixedPosition = position;
+        }
+
+        public void setLocked(bool locked)
+        {
+            isLocked = locked;
+        }
+    }
+
     [HarmonyPatch(typeof(MainMenu))]
     public class MainMenuPatches
     {
@@ -31,6 +62,18 @@ namespace StationeersVR
             menuCanvas.transform.rotation = new Quaternion(0f, 1f, 0f, 0f);
             menuCanvas.transform.localScale = new Vector3(0.001043074f, 0.001043074f, 0.001043074f);
             menuCanvas.transform.Rotate(Vector3.up, -30f);
+
+            // Don't allow the game to move the camera while we're in the menu. Clicking "New Game" wants
+            // to rotate and move the camera, for example. As the menus are in world space, this means we
+            // end up no longer being able to see the menus easily.
+            ModLog.Debug("Locking Main Camera xform");
+            Camera mainCamera = CameraUtils.GetCamera(CameraUtils.MAIN_CAMERA);
+            TransformLock txLockComponent = mainCamera.gameObject.AddComponent<TransformLock>();
+            txLockComponent.SetRotation(mainCamera.transform.rotation);
+            txLockComponent.SetPosition(mainCamera.transform.position);
+
+            menuCanvas.gameObject.AddComponent<GraphicRaycaster>();
+            menuCanvas.worldCamera = CameraUtils.GetCamera(CameraUtils.VR_CAMERA);
         }
 
 

--- a/StationeersVRMod/Utilities/GazeCursor.cs
+++ b/StationeersVRMod/Utilities/GazeCursor.cs
@@ -44,10 +44,8 @@ namespace StationeersVR.Utilities
                 lineMaterial = new Material(CursorManager.Instance.CursorShader);
                 lineMaterial.color = Color.red;
                 if (line == null)
-                    gameObject.AddComponent<LineRenderer>();
-                else
-                    line = gameObject.GetComponent<LineRenderer>();
-                line.GetComponent<Renderer>().material = lineMaterial;
+                    line = gameObject.AddComponent<LineRenderer>();
+                line.material = lineMaterial;
                 line.startColor = new Color(0f, 1f, 1f, 1f);
                 line.endColor = new Color(1f, 0f, 0f, 1f);
                 line.startWidth = 0.002f;
@@ -101,14 +99,14 @@ namespace StationeersVR.Utilities
                 //Scale The Cursor so it's not to small when far and to big when close
                 ScaleCusorSphere();
                 oldSortingOrder = cursorInstance.GetComponent<Renderer>().sortingOrder;
-                //This Raycast that hits the UI,Iventory,menus ect.
+                //This Raycast that hits the UI, Iventory, menus ect.
                 if (raycast.gameObject != null && raycast.distance < InputMouse.MaxInteractDistance)
                 {
                     cursorInstance.GetComponent<Renderer>().sortingOrder = raycast.gameObject.GetComponentInParent<Canvas>().sortingOrder;
                     cursorInstance.transform.position = raycast.worldPosition;
                     cursorMaterial.color = Color.green;
                 }
-                //This Raycast hits switches,items any interactable but anything with UI
+                //This Raycast hits switches, items any interactable but not anything with UI
                 else if (CursorManager._raycastHit.transform != null && CursorManager._raycastHit.distance < InputMouse.MaxInteractDistance)
                 {
                     cursorInstance.transform.position = CursorManager._raycastHit.point;
@@ -116,7 +114,6 @@ namespace StationeersVR.Utilities
                 }
                 else
                 {
-                    cursorMaterial.color = Color.white;
                     //These are here so the pointer stays in place or does not disappear when it has no hit point, both gaze and mouse cursor here
                     if (Cursor.lockState == CursorLockMode.None)
                     {
@@ -136,6 +133,10 @@ namespace StationeersVR.Utilities
         }
         private void UpdateDebugPointer()
         {
+            if (Camera.current == null)
+            {
+                return;
+            }
             if (pointerDebug)
             {
                 if (raycast.gameObject != null && raycast.distance < InputMouse.MaxInteractDistance)

--- a/StationeersVRMod/VRCore/VRPlayer.cs
+++ b/StationeersVRMod/VRCore/VRPlayer.cs
@@ -659,6 +659,8 @@ namespace StationeersVR.VRCore
 //            vrCam.cullingMask &= ~(1 << LayerUtils.getHandsLayer());
 //            vrCam.cullingMask &= ~(1 << LayerUtils.getWorldspaceUiLayer());
             mainCamera.enabled = false;
+            mainCamera.gameObject.tag = "Untagged";
+            vrCam.tag = "MainCamera";
             AudioListener mainCamListener = mainCamera.GetComponent<AudioListener>();
             if (mainCamListener != null)
             {


### PR DESCRIPTION
- Stop the camera from snapping upwards when selecting "New Game" in the menu
- Retag the VR Camera as the "Main Camera"
- Small fixes for the debug line renderer
- Add VSCode directory to gitignore